### PR TITLE
licence(#7): PMPL-1.0 -> PMPL-1.0-or-later (owner carve-out, SPDX-only)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: PMPL-1.0
+# SPDX-License-Identifier: PMPL-1.0-or-later
 name: CodeQL Security Analysis
 
 on:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: PMPL-1.0
+# SPDX-License-Identifier: PMPL-1.0-or-later
 name: OSSF Scorecard
 on:
   push:

--- a/.github/workflows/secret-scanner.yml
+++ b/.github/workflows/secret-scanner.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: PMPL-1.0
+# SPDX-License-Identifier: PMPL-1.0-or-later
 # Prevention workflow - scans for hardcoded secrets before they reach main
 name: Secret Scanner
 


### PR DESCRIPTION
3 files, SPDX-value-only suffix fix. NOT a relicence (same licence). Owner-sanctioned carve-out, standards LICENCE-POLICY A8(1). Refs LICENCE-DEBT-LEDGER-2026-05-18. 🤖 Generated with [Claude Code](https://claude.com/claude-code)