### PR TITLE
chore(ci): replace secret-scanner.yml with reusable wrapper

### DIFF
--- a/.github/workflows/secret-scanner.yml
+++ b/.github/workflows/secret-scanner.yml
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: MPL-2.0
-# Prevention workflow - scans for hardcoded secrets before they reach main
 name: Secret Scanner
 
 on:
@@ -7,10 +6,6 @@ on:
   push:
     branches: [main]
 
-# Estate guardrail: cancel superseded runs so re-pushes / rebased PR
-# updates do not pile up queued runs against the shared account-wide
-# Actions concurrency pool. Applied only to read-only check workflows
-# (no publish/mutation), so cancelling a superseded run is always safe.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -19,63 +14,6 @@ permissions:
   contents: read
 
 jobs:
-  trufflehog:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
-        with:
-          fetch-depth: 0  # Full history for scanning
-
-      - name: TruffleHog Secret Scan
-        uses: trufflesecurity/trufflehog@6c05c4a00b91aa542267d8e32a8254774799d68d # v3
-        with:
-          # The v3 action injects --fail automatically on pull_request events.
-          # Passing --fail here triggers "flag 'fail' cannot be repeated".
-          extra_args: --only-verified
-
-  gitleaks:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
-        with:
-          fetch-depth: 0
-
-      - name: Gitleaks Secret Scan
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # Rust-specific: Check for hardcoded crypto values
-  rust-secrets:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
-
-      - name: Check for hardcoded secrets in Rust
-        run: |
-          if ! find . -name Cargo.toml -not -path './target/*' -print -quit | grep -q .; then
-            echo 'No Cargo.toml found — skipping Rust secrets check'
-            exit 0
-          fi
-          # Patterns that suggest hardcoded secrets
-          PATTERNS=(
-            'const.*SECRET.*=.*"'
-            'const.*KEY.*=.*"[a-zA-Z0-9]{16,}"'
-            'const.*TOKEN.*=.*"'
-            'let.*api_key.*=.*"'
-            'HMAC.*"[a-fA-F0-9]{32,}"'
-            'password.*=.*"[^"]+"'
-          )
-
-          found=0
-          for pattern in "${PATTERNS[@]}"; do
-            if grep -rn --include="*.rs" -E "$pattern" src/; then
-              echo "WARNING: Potential hardcoded secret found matching: $pattern"
-              found=1
-            fi
-          done
-
-          if [ $found -eq 1 ]; then
-            echo "::error::Potential hardcoded secrets detected. Use environment variables instead."
-            exit 1
-          fi
+  scan:
+    uses: hyperpolymath/standards/.github/workflows/secret-scanner-reusable.yml@3e4bd4c93911750727e2e4c66dff859e00079da0
+    secrets: inherit


### PR DESCRIPTION
## Summary
Replaces this repo's `secret-scanner.yml` (~75-116 lines) with a thin ~14-line wrapper calling `hyperpolymath/standards/.github/workflows/secret-scanner-reusable.yml@3e4bd4c93911750727e2e4c66dff859e00079da0` (merged via standards#190).

## Security debt closed
The `shell-secrets` job (added to the canonical 2026-05-21 in direct response to the live Cloudflare API token leak via `avow-protocol/deploy-repos.sh` — a leak both `trufflehog --only-verified` and default `gitleaks` missed) was carried by 0 of 16 sampled estate copies. This PR brings that guardrail to this repo.

## Why now
Estate audit: 281 `secret-scanner.yml` deployments / 54 unique SHAs / 19% true drift. Drift is pin churn + whitespace; feature variance is near-zero. Converging behind the reusable means the next post-incident guardrail update propagates via one SHA bump.

`secrets: inherit` flows `GITHUB_TOKEN` through implicitly so the `gitleaks-action` step doesn't fall back to anonymous (rate-limited) mode.

Part of estate-wide convergence campaign 2026-05-26 (standards#199 / #190).