### PR TITLE
chore(ci): replace scorecard.yml with reusable wrapper

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,41 +1,16 @@
 # SPDX-License-Identifier: MPL-2.0
-name: OSSF Scorecard
+name: Scorecards supply-chain security
+
 on:
-  push:
-    branches: [main, master]
+  branch_protection_rule:
   schedule:
-    - cron: '0 4 * * *'
-  workflow_dispatch:
+    - cron: '23 4 * * 1'
+  push:
+    branches: [main]
 
-# Estate guardrail: cancel superseded runs so re-pushes / rebased PR
-# updates do not pile up queued runs against the shared account-wide
-# Actions concurrency pool. Applied only to read-only check workflows
-# (no publish/mutation), so cancelling a superseded run is always safe.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   analysis:
-    runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-      id-token: write
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Run Scorecard
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.3.1
-        with:
-          results_file: results.sarif
-          results_format: sarif
-
-      - name: Upload results
-        uses: github/codeql-action/upload-sarif@c6f931105cb2c34c8f901cc885ba1e2e259cf745 # v3.31.8
-        with:
-          sarif_file: results.sarif
+    uses: hyperpolymath/standards/.github/workflows/scorecard-reusable.yml@e0caf11508a3989574713c78f5f444f2ce5e33ef
+    secrets: inherit


### PR DESCRIPTION
Pins to hyperpolymath/standards#205 merge SHA `e0caf11508a3989574713c78f5f444f2ce5e33ef`. Replaces the canonical scorecard.yml with a thin wrapper. Closes the 5-candidate convergence set.

Estate audit: 258 deploys / 18% drift / 39% top-SHA share.

Part of estate-wide convergence campaign 2026-05-26 (standards#199 / #205).