### PR TITLE
docs(readme): flip stale PMPL-1.0 license badge to MPL-2.0

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,7 @@
 = Causals.jl
 
 image:https://img.shields.io/badge/OpenSSF-Best_Practices-green?logo=opensourcesecurity[OpenSSF Best Practices,link="https://www.bestpractices.dev/en/projects/new?repo_url=https://github.com/hyperpolymath/Causals.jl"]
-image:https://img.shields.io/badge/License-PMPL--1.0-blue.svg[License: PMPL-1.0,link="https://github.com/hyperpolymath/palimpsest-license"]
+image:https://img.shields.io/badge/License-MPL--2.0-blue.svg[License: MPL-2.0,link="https://www.mozilla.org/MPL/2.0/"]
 image:https://api.thegreenwebfoundation.org/greencheckimage/github.com[Green Web,link="https://www.thegreenwebfoundation.org/green-web-check/?url=github.com"]
 
 :toc: macro


### PR DESCRIPTION
Single-line README badge polish. Per 2026-06-02 estate license policy.